### PR TITLE
getRepresentativeImage 메소드 수정

### DIFF
--- a/src/utils/post.ts
+++ b/src/utils/post.ts
@@ -38,7 +38,7 @@ export const getAllPosts = async ({
     filePaths.map(async (filePath) => {
       const fileContents = await fs.readFile(filePath, "utf8");
       const { data, content } = matter(fileContents);
-      const thumbnail = await getRepresentativeImage(data, content);
+      const thumbnail = getRepresentativeImage(data, content);
 
       if (
         !data?.title ||
@@ -156,7 +156,7 @@ export const getPostsByTag = async (
     filePaths.map(async (filePath) => {
       const fileContents = await fs.readFile(filePath, "utf8");
       const { data, content } = matter(fileContents);
-      const thumbnail = await getRepresentativeImage(data, content);
+      const thumbnail = getRepresentativeImage(data, content);
 
       if (!data?.title || !data?.tags || !data?.category || !data?.createdAt) {
         console.warn(`🛠️  ${filePath} 파일에서 필수 메타데이터가 없습니다.`);


### PR DESCRIPTION
SSR 환경에서만 쓰이는 getRepresentativeImage메소드가 getAllPosts 메소드내에서 … 무조건 fallback 이미지를 내뱉는 이슈 수정 -> SSR에서만 쓰이도록 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 썸네일 추출을 동기 방식으로 전환해 SSR에서 외부 요청 없이 즉시 결정됩니다.
  - 프론트매터의 thumbnail을 우선 사용하고, 없으면 본문 첫 이미지를 자동 추출합니다.
  - 유효하지 않은 경우 기본 이미지로 안정적으로 폴백합니다.
  - 글 목록 및 태그별 목록에서도 썸네일이 즉시 반영되어 렌더링 안정성이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->