### PR TITLE
sitemap.xml이 자기자신을 참조하는 이슈 수정

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -41,7 +41,6 @@ const config = {
       { userAgent: "*", allow: "/" },
       { userAgent: "*", disallow: ["/api/"] },
     ],
-    additionalSitemaps: [`${process.env.NEXT_PUBLIC_SITE_URL}/sitemap.xml`],
   },
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * robots.txt 설정에서 추가 사이트맵 링크를 제거해 구성 중복을 해소하고 유지보수를 단순화했습니다.
  * 검색엔진에는 단일 사이트맵만 노출되어 크롤링 지시가 더 일관되게 전달됩니다.
  * 기존 robots 정책 등 다른 설정은 변경되지 않았으며, SEO 동작에는 영향이 없습니다.
  * 배포나 사용 방식의 변화는 없고, 가시적 UI 변경도 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->