### PR TITLE
getMdxContents 메소드에서 serialize를 옵셔널하게 사용할 수 있도록 수정

### DIFF
--- a/src/templates/MdxDetailTemplate/MdxDetailTemplate.tsx
+++ b/src/templates/MdxDetailTemplate/MdxDetailTemplate.tsx
@@ -1,5 +1,5 @@
 import CodeBlock from "@/components/CodeBlock";
-import { MDXRemoteProps, MDXRemoteSerializeResult } from "next-mdx-remote";
+import { MDXRemoteProps } from "next-mdx-remote";
 import TimeIcon from "@/icon/time.svg";
 import { FrontMatterProps, HeadingsProps } from "@/types/mdx";
 import MdxLink from "@/components/MdxLink";
@@ -28,7 +28,7 @@ type MdxDetailRelatedPost = {
 };
 
 interface MdxDetailTemplateProps {
-  source: MDXRemoteSerializeResult;
+  source: string;
   frontMatter: FrontMatterProps;
   readingTime?: number;
   heading?: HeadingsProps[];

--- a/src/types/mdx.ts
+++ b/src/types/mdx.ts
@@ -1,5 +1,5 @@
-import { MDXRemoteSerializeResult } from "next-mdx-remote";
-import { RelatedPost } from "./posts";
+import { extractHeadings } from "@/utils/mdx";
+
 export interface FrontMatterProps {
   title: string;
   description: string;
@@ -25,17 +25,34 @@ export type ExtendedElement = {
   properties?: Record<string, any>;
 };
 
-export interface getMdxContentsResponse {
-  source: MDXRemoteSerializeResult;
+export type RehypePlugin =
+  | ((...args: any[]) => any)
+  | [(...args: any[]) => any, Record<string, any>?];
+
+export type RehypePluginList = RehypePlugin[];
+
+// 공통 반환형 (제네릭)
+export type GetMdxContentsBase<S> = {
+  source: S; // string | MDXRemoteSerializeResult
   frontMatter: FrontMatterProps;
-  readingTime?: number;
-  heading?: HeadingsProps[];
-  previousPost: RelatedPost | null;
-  nextPost: RelatedPost | null;
-  relatedPosts: RelatedPost[] | null;
-}
+  readingTime: number;
+  heading: ReturnType<typeof extractHeadings>;
+  previousPost: { slug: string; title: string } | null;
+  nextPost: { slug: string; title: string } | null;
+  relatedPosts: { slug: string; title: string }[];
+  rehypePlugins: RehypePluginList;
+};
 
 export interface HeadingItems {
   value?: string;
   type?: string;
 }
+
+export type SerializeOptions = {
+  mdxOptions?: {
+    remarkPlugins?: any[];
+    rehypePlugins?: any[];
+    format?: "mdx" | "md";
+  };
+  scope?: Record<string, unknown>;
+};

--- a/src/utils/post.ts
+++ b/src/utils/post.ts
@@ -12,12 +12,13 @@ import {
   getPostsByCategoryResponse,
 } from "@/types/posts";
 import { getMdxContents, getRepresentativeImage } from "./mdx";
-import { getMdxContentsResponse } from "@/types/mdx";
+
 import {
   CATEGORY_MAP,
   DEFAULT_PAGE_SIZE,
   SUB_CATEGORY_MAP,
 } from "@/constants/post.constants";
+import { GetMdxContentsBase } from "@/types/mdx";
 
 const POST_PATH = path.join(process.cwd(), "src/mdx/content");
 
@@ -136,8 +137,10 @@ export const getAllPosts = async ({
 
 export const getPostsDetail = async (
   slug: string[],
-): Promise<getMdxContentsResponse | null> => {
-  const mdxContentData = await getMdxContents(slug, POST_PATH, false);
+): Promise<GetMdxContentsBase<string> | null> => {
+  const mdxContentData = await getMdxContents(slug, POST_PATH, false, {
+    serialize: false as const,
+  });
   return mdxContentData;
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - MDX 처리 방식 선택(직렬화 온/오프) 지원으로 유연한 콘텐츠 로딩.
  - 사용자 정의 MDX 옵션과 remark/rehype 플러그인 구성이 가능해져 렌더링 확장성 향상.
  - 관련 글 계산 로직 개선으로 더 적합한 추천 목록 제공.
  - 읽기 시간 정보가 항상 제공되어 가독성 판단이 쉬워짐.

- 버그 수정
  - 존재하지 않는 MDX 파일을 안정적으로 처리하여 오류 발생을 방지.

- 리팩터링
  - MDX 데이터 모델을 범용 구조로 정비하여 일관성과 확장성 개선.
  - 템플릿과 유틸 함수의 타입 정리로 유지보수성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->