### PR TITLE
fix: about 페이지 og image 추가

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -47,6 +47,14 @@ export const metadata: Metadata = {
     url: "/about",
     type: "profile",
     siteName: "SEOK 블로그",
+    images: [
+      {
+        url: "/image/og_image.png",
+        width: 1200,
+        height: 630,
+        alt: "김형석 블로그 OG 이미지",
+      },
+    ],
     locale: "ko_KR",
   },
   twitter: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * About 페이지에 소셜 미디어 공유 시 표시될 Open Graph 메타데이터를 추가했습니다. 페이스북, 트위터 등 소셜 플랫폼에서 페이지를 공유할 때 최적화된 미리보기 이미지가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->